### PR TITLE
Fix error to be risen by `EbayRequest::Trading#request`

### DIFF
--- a/lib/ebay_request/trading.rb
+++ b/lib/ebay_request/trading.rb
@@ -58,7 +58,7 @@ class EbayRequest::Trading < EbayRequest::Base
     super.tap do |response|
       next if retried || options[:iaf_token_manager].nil?
       next if response.success? || response.error_class > IAFTokenExpired
-      raise response.error_class
+      raise response.error
     end
   rescue IAFTokenExpired
     options[:iaf_token_manager].refresh!


### PR DESCRIPTION
Unlike `EbayRequest::Response#error_class`, the `EbayRequest::Response#error` is an istance of error_class, that contains a hash of error messages assotiated to their codes.

Knowledge of those codes is essential for processing errors correctly (by the app that can not be called)